### PR TITLE
Typo in comments of .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,2 +1,2 @@
-# Inlcude our .bash_profile as long as we're in an interactive shell
+# Include our .bash_profile as long as we're in an interactive shell
 [ -n "$PS1" ] && . ~/.bash_profile


### PR DESCRIPTION
Fixes a typo
