### PR TITLE
Make the server function serve without errors.

### DIFF
--- a/.functions
+++ b/.functions
@@ -2,8 +2,8 @@
 
 function server {
     local port="${1:-8000}"
-    python -m SimpleHTTPServer [port]
-    open "http://127.0.0.1:${port}/"
+    sleep 1 && open "http://127.0.0.1:${port}/" &
+    python -m SimpleHTTPServer $port
 }
 
 # Recursively delete .DS_Store files from the current directory.


### PR DESCRIPTION
Fixes issue described in: https://github.com/jedrichards/dotfiles/issues/3

Also swapped order of lines 5 and 6.  If `python -m SimpleHTTPServer $port` runs successfully, the next line will not be executed until you kill the running server.  So with credit to https://github.com/mathiasbynens/dotfiles/blob/master/.functions#L100, open the browser with a delay and in the meantime run the server.
